### PR TITLE
Add bluetooth permission description

### DIFF
--- a/src/cli/Info.plist.in
+++ b/src/cli/Info.plist.in
@@ -30,5 +30,7 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Scanning for and connecting to Pokit devices</string>
 </dict>
 </plist>


### PR DESCRIPTION
This change allows macos to request bluetooth permissions and makes `./build/src/cli/dokit.app/Contents/MacOS/dokit scan` work.

Resolves #9